### PR TITLE
cmake: compilers: Fix Clang compiler detection

### DIFF
--- a/{{cookiecutter.project_slug}}/cmake/compilers.cmake
+++ b/{{cookiecutter.project_slug}}/cmake/compilers.cmake
@@ -3,7 +3,7 @@ include_guard()
 # Define variables for each supported compiler, so that checking is easier
 # later.
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(USING_CLANG TRUE)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(USING_GCC TRUE)


### PR DESCRIPTION
"CMAKE_CXX_COMPILER_ID" can be both "Clang" or "AppleClang", 
where the second one appears under MacOS.